### PR TITLE
Handle crashing error if no templates are present

### DIFF
--- a/browser/react-wallet/src/pages/IssueCredentialPage.js
+++ b/browser/react-wallet/src/pages/IssueCredentialPage.js
@@ -107,6 +107,7 @@ export class IssueCredentialPage extends React.Component {
   }
 
   renderTemplateFields() { 
+    if (!this.state.selectedTemplate) return;
     const fields = this.state.selectedTemplate.fields;
     const keys = Object.keys(fields);
     return keys.map((key, index) => 


### PR DESCRIPTION
Fixes a bug that causes the app to crash if there were no credential templates created before visiting the credential issuance page