### PR TITLE
fix: React-Wallet using different ecosystem

### DIFF
--- a/browser/react-wallet/src/actions/index.ts
+++ b/browser/react-wallet/src/actions/index.ts
@@ -37,6 +37,8 @@ export function login(email: string, name: string): ThunkAction<void, ActionStat
         const loginResponse: LoginResponse = await service.account().login(
             LoginRequest.fromPartial({
                 email,
+                //Change this to your ecosystem id
+                ecosystemId: "default"
             })
         );
 

--- a/browser/react-wallet/src/reducers/Ecosystems.ts
+++ b/browser/react-wallet/src/reducers/Ecosystems.ts
@@ -1,21 +1,18 @@
 import { CREATE_ECOSYSTEM, GET_ECOSYSTEM_INFO } from '../actions';
 // initialState
-export const ecosystems = {
+export const ecosystems: EcosystemState = {
   currentEcosystem: { name: "" }
 }
 
 export interface EcosystemAction { type: string; ecosystem: any; }
+export interface EcosystemState { currentEcosystem: {name: string } }
 
-export default function ecosystemReducer(state = ecosystems, action: EcosystemAction) {
+export default function ecosystemReducer(state = ecosystems, action: EcosystemAction) : EcosystemState {
   switch (action.type) {
     case CREATE_ECOSYSTEM:
-      return Object.assign({}, state, {
-        currentEcosystem: action.ecosystem
-      });
+      return {...state, currentEcosystem: action.ecosystem};
     case GET_ECOSYSTEM_INFO:
-      return Object.assign({}, state, {
-        currentEcosystem: action.ecosystem
-      });
+      return {...state, currentEcosystem: action.ecosystem};
     default:
       return state;
   }

--- a/browser/react-wallet/src/reducers/Ecosystems.ts
+++ b/browser/react-wallet/src/reducers/Ecosystems.ts
@@ -1,7 +1,7 @@
 import { CREATE_ECOSYSTEM, GET_ECOSYSTEM_INFO } from '../actions';
 // initialState
 export const ecosystems = {
-  currentEcosytem: { name: "" }
+  currentEcosystem: { name: "" }
 }
 
 export interface EcosystemAction { type: string; ecosystem: any; }
@@ -10,11 +10,11 @@ export default function ecosystemReducer(state = ecosystems, action: EcosystemAc
   switch (action.type) {
     case CREATE_ECOSYSTEM:
       return Object.assign({}, state, {
-        currentEcosytem: action.ecosystem
+        currentEcosystem: action.ecosystem
       });
     case GET_ECOSYSTEM_INFO:
       return Object.assign({}, state, {
-        currentEcosytem: action.ecosystem
+        currentEcosystem: action.ecosystem
       });
     default:
       return state;

--- a/browser/react-wallet/src/types.ts
+++ b/browser/react-wallet/src/types.ts
@@ -1,5 +1,7 @@
+import { EcosystemState } from "./reducers/Ecosystems";
+
 export type AppProps = { loggedIn: boolean; logout: Function; ecosystem?: { name: string | undefined; }; }
-export type AppState = { authentication: { loggedIn: boolean; }; ecosystems: { currentEcosystem: any; }; }
+export type AppState = { authentication: { loggedIn: boolean; }; ecosystems: EcosystemState; }
 
 export type ActionState = {
     wallet: any; (): any; new(): any; authentication: {


### PR DESCRIPTION
3 individual fixes (in 3 commits)
1. Adding the ecosystem id to signal it's customizable
2. Fixing a typo in the ecosystem reducer (therefore not rendering the different name)
3. Adding types to the ecosystem reducer to flag the typo through Typescript