### PR TITLE
dependencies: Enable Renovate Dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,5 +18,6 @@
     }
   ],
   "prHourlyLimit": 20,
-  "prConcurrentLimit": 0
+  "prConcurrentLimit": 0,
+  "dependencyDashboard": true
 }


### PR DESCRIPTION
Helpful for this as you can trigger scans again, people updating SDKs and samples will want to get these trigger on demand.